### PR TITLE
fix: constrain chat code block rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -239,37 +239,34 @@
   display: none;
 }
 
-div.hidden.overflow-x-auto.dark\:block.\[\&\>pre\]\:bg-transparent\!.my-4.h-auto.rounded-lg.border.p-4.language-tsx {
-  padding: 0 !important;
+.markdown-content {
+  @apply w-full min-w-0 max-w-full;
 }
-div.hidden.overflow-x-auto.dark\:block.\[\&\>pre\]\:bg-transparent\!.my-4.h-auto.rounded-lg.border.p-4.language-tsx
-  > pre {
-  padding: 1rem;
+
+.markdown-content [class*="language-"] {
+  @apply max-w-full overflow-x-auto;
 }
-div.hidden.overflow-x-auto.dark\:block.\[\&\>pre\]\:bg-transparent\!.my-4.h-auto.rounded-lg.border.p-4.language-tsx {
-  max-width: 85vw;
-  background-color: #24292e;
+
+.markdown-content [class*="language-"] > pre {
+  @apply m-0 p-0;
 }
-div.overflow-x-auto.dark\:hidden.\[\&\>pre\]\:bg-transparent\!.my-4.h-auto.rounded-lg.border.p-4.language-tsx {
-  max-width: 85vw;
-  background-color: #fff;
+
+.markdown-content [class*="language-"] pre code {
+  white-space: pre;
 }
-div.overflow-x-auto.dark\:hidden.\[\&\>pre\]\:bg-transparent\!.my-4.h-auto.rounded-lg.border.p-4.language-tsx
-  > pre {
-  padding: 0 !important;
-}
-.language-tsx::-webkit-scrollbar {
+
+.markdown-content [class*="language-"]::-webkit-scrollbar {
   width: 6px;
   height: 2px;
   background-color: transparent;
 }
 
-.language-tsx::-webkit-scrollbar-thumb {
+.markdown-content [class*="language-"]::-webkit-scrollbar-thumb {
   background-color: rgba(215, 215, 215, 0.564);
   border-radius: 8px;
   transition: background-color 0.2s;
 }
 
-.language-tsx::-webkit-scrollbar-thumb:hover {
+.markdown-content [class*="language-"]::-webkit-scrollbar-thumb:hover {
   background-color: rgba(193, 193, 193, 0.455);
 }

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -21,7 +21,12 @@ const components: Partial<Components> = {
 }
 
 const NonMemoizedMarkdown = ({ children }: { children: string }) => (
-  <Streamdown components={components}>{children}</Streamdown>
+  <Streamdown
+    className="markdown-content min-w-0 max-w-full"
+    components={components}
+  >
+    {children}
+  </Streamdown>
 )
 
 export const Markdown = memo(

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -7,7 +7,10 @@ import { memo, useMemo, useState } from "react"
 
 import type { Vote } from "@/lib/db/schema"
 
+import { cn } from "@/lib/utils"
+import equal from "fast-deep-equal"
 import { DocumentToolCall, DocumentToolResult } from "./document"
+import { DocumentPreview } from "./document-preview"
 import {
   ChevronDownIcon,
   LoaderIcon,
@@ -16,15 +19,12 @@ import {
 } from "./icons"
 import { Markdown } from "./markdown"
 import { MessageActions } from "./message-actions"
+import { MessageEditor } from "./message-editor"
+import { MessageReasoning } from "./message-reasoning"
 import { PreviewAttachment } from "./preview-attachment"
-import { Weather } from "./weather"
-import equal from "fast-deep-equal"
-import { cn } from "@/lib/utils"
 import { Button } from "./ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip"
-import { MessageEditor } from "./message-editor"
-import { DocumentPreview } from "./document-preview"
-import { MessageReasoning } from "./message-reasoning"
+import { Weather } from "./weather"
 
 const PurePreviewMessage = ({
   chatId,
@@ -113,7 +113,7 @@ const PurePreviewMessage = ({
                 )}
 
                 <div
-                  className={cn("flex flex-col gap-4", {
+                  className={cn("flex min-w-0 max-w-full flex-col gap-4", {
                     "bg-primary text-primary-foreground px-3 py-2 rounded-xl":
                       message.role === "user",
                   })}


### PR DESCRIPTION
Fixes #44

Summary:
- Scope markdown code block sizing through `.markdown-content`.
- Replace brittle TSX-only global selectors with language-agnostic code block rules.
- Allow message markdown flex items to shrink so long code blocks scroll instead of breaking layout.

Verification:
- `bun x biome check components\markdown.tsx components\message.tsx app\globals.css`
- `bun x tsc --noEmit --incremental false`
- `bun run build`
- `git diff --check`